### PR TITLE
Fixed: Last Updated Date in testing data gives incorrect month

### DIFF
--- a/refresh-icmr.js
+++ b/refresh-icmr.js
@@ -70,7 +70,7 @@ function getLastUpdated(content) {
     if (!m || m.length !== 6) return "1970-01-01T00:00:00.000Z";
 
     const day = parseInt(m[1]);
-    const month = parseInt(m[2]);
+    const month = parseInt(m[2])-1;
     const year = parseInt(m[3]);
     const hour = parseInt(m[4]);
     const min = parseInt(m[5]);


### PR DESCRIPTION
Hi,

Fixing #18 , the date extraction logic used while retrieving testing data takes the month from the date itself. The [Javascript date library](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC) has 0-indexed months that was not accounted for.

